### PR TITLE
Fix pinned dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,0 @@
-opal-common>=0.1.11
-asyncpg==0.23.0
-pydantic==1.8.2
-tenacity==6.3.1
-click<7.2.0,>=7.1.1

--- a/setup.py
+++ b/setup.py
@@ -29,5 +29,11 @@ setup(
         'Programming Language :: Python :: 3.9'
     ],
     python_requires='>=3.7',
-    install_requires=get_requirements(),
+    install_requires=[
+        'opal-common>=0.1.11',
+        'asyncpg',
+        'pydantic',
+        'tenacity',
+        'click'
+    ],
 )


### PR DESCRIPTION
This package had most of its dependencies pinned
to specific verisons, but not all. This created
an un-installable dependency tree.

This commit releases all dependencies other than OPAL
from any constraints.