### PR TITLE
add support for hashing records by a specified key column

### DIFF
--- a/opal_fetcher_postgres/provider.py
+++ b/opal_fetcher_postgres/provider.py
@@ -45,6 +45,7 @@ class PostgresFetcherConfig(FetcherConfig):
     connection_params: Optional[PostgresConnectionParams] = Field(None, description="these params can override or complement parts of the dsn (connection string)")
     query: str = Field(..., description="the query to run against postgres in order to fetch the data")
     fetch_one: bool = Field(False, description="whether we fetch only one row from the results of the SELECT query")
+    key: Optional[str] = Field(None, description="if provided will store records as an object whose keys are the values in the column specified by this field (e.g. key = 'id')")
 
 
 class PostgresFetchEvent(FetchEvent):
@@ -149,6 +150,9 @@ class PostgresFetchProvider(BaseFetchProvider):
                 return dict(records[0])
             else:
                 return {}
+        elif self._event.config.key != None:
+            keys = [str(record[self._event.config.key]) for record in records]
+            return dict(zip(keys, [dict(record) for record in records]))
         else:
             # we transform the asyncpg records to a list-of-dicts that we can be later serialized to json
             return [dict(record) for record in records]


### PR DESCRIPTION
being able to hash items pulled from postgres by some specified key column integrates well with the `fetch_one` config option, allowing applications to later update a specific item in a collection by that key rather than providing an index into an array