### PR TITLE
Add fetch_key to map the data to an object by primary key

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,6 +51,7 @@ services:
       # configures from where the opal client should initially fetch data (when it first goes up, after disconnection, etc).
       # the data sources represents from where the opal clients should get a "complete picture" of the data they need.
       # after the initial sources are fetched, the client will subscribe only to update notifications sent by the server.
+      # Add "fetch_key":"city_id" to get an object with keys of city_id, rather than a list
       - OPAL_DATA_CONFIG_SOURCES={"config":{"entries":[{"url":"postgresql://postgres@example_db:5432/postgres","config":{"fetcher":"PostgresFetchProvider","query":"SELECT * from city;","connection_params":{"password":"postgres"}},"topics":["policy_data"],"dst_path":"cities"}]}}
     ports:
       # exposes opal server on the host machine, you can access the server at: http://localhost:7002


### PR DESCRIPTION
This PR adds a parameter to the fetcher to map the returned data to an object rather than a list. The parameter `fetch_key` accepts a column name from the returned Record to map the data using that key on the object. This can be done to allow simple retrieval by id, for [performance reasons](https://www.openpolicyagent.org/docs/latest/policy-performance/#use-objects-over-arrays) or in the case your query is using a group by clause and you'd like to key off of that grouping. 

Sample of returned object where the parameter `"fetch_key":"city_id"` is added to the configuration. 
http://localhost:8181/v1/data/cities
<img width="455" alt="image" src="https://github.com/permitio/opal-fetcher-postgres/assets/52041689/34a01057-fe42-4fe7-8390-ffa671ec4b1c">

Retrieving a city by id:
<img width="521" alt="image" src="https://github.com/permitio/opal-fetcher-postgres/assets/52041689/b6a471b3-6205-418a-9300-9a971d74427d">

If the values in the fetch_key are not unique, records will overwrite others and only one will be returned. For example, adding `"fetch_key":"country_id"` will return one city per country.