### PR TITLE
fix: fetch_key data processing leaving out last record

### DIFF
--- a/src/opal_fetcher_postgres/provider.py
+++ b/src/opal_fetcher_postgres/provider.py
@@ -186,5 +186,5 @@ class PostgresFetchProvider(BaseFetchProvider):
                 return [dict(record) for record in records]
             else:
                 # we transform the asyncpg records to a dict-of-dicts that we can be later serialized to json
-                res_dct = map(lambda i: (records[i][self._event.config.fetch_key], dict(records[i])), range(len(records)-1))
+                res_dct = map(lambda i: (records[i][self._event.config.fetch_key], dict(records[i])), range(len(records)))
                 return dict(res_dct)


### PR DESCRIPTION
This fixes a bug where the last record is left out from the result when utilizing fetch_key

I stumbled upon this when I was trying out the fetch key feature with just a few records, and noticed that the `range(len(records)-1)` actually strips away the last record.

## Repro 
When running docker-compose up with the default configuration and querying localhost:8181/v1/data/cities we get an array containing 30 cities.

```json
{
    "result": [
        {
            "city_id": 1,
            "city_name": "City 1",
            "country_id": 95
        },
        {
            "city_id": 2,
            "city_name": "City 2",
            "country_id": 52
        },
        {
            "city_id": 3,
            "city_name": "City 3",
            "country_id": 1
        },
        {
            "city_id": 4,
            "city_name": "City 4",
            "country_id": 51
        },
        {
            "city_id": 5,
            "city_name": "City 5",
            "country_id": 52
        },
        {
            "city_id": 6,
            "city_name": "City 6",
            "country_id": 55
        },
        {
            "city_id": 7,
            "city_name": "City 7",
            "country_id": 37
        },
        {
            "city_id": 8,
            "city_name": "City 8",
            "country_id": 22
        },
        {
            "city_id": 9,
            "city_name": "City 9",
            "country_id": 80
        },
        {
            "city_id": 10,
            "city_name": "City 10",
            "country_id": 65
        },
        {
            "city_id": 11,
            "city_name": "City 11",
            "country_id": 7
        },
        {
            "city_id": 12,
            "city_name": "City 12",
            "country_id": 33
        },
        {
            "city_id": 13,
            "city_name": "City 13",
            "country_id": 12
        },
        {
            "city_id": 14,
            "city_name": "City 14",
            "country_id": 72
        },
        {
            "city_id": 15,
            "city_name": "City 15",
            "country_id": 44
        },
        {
            "city_id": 16,
            "city_name": "City 16",
            "country_id": 77
        },
        {
            "city_id": 17,
            "city_name": "City 17",
            "country_id": 89
        },
        {
            "city_id": 18,
            "city_name": "City 18",
            "country_id": 56
        },
        {
            "city_id": 19,
            "city_name": "City 19",
            "country_id": 46
        },
        {
            "city_id": 20,
            "city_name": "City 20",
            "country_id": 45
        },
        {
            "city_id": 21,
            "city_name": "City 21",
            "country_id": 40
        },
        {
            "city_id": 22,
            "city_name": "City 22",
            "country_id": 81
        },
        {
            "city_id": 23,
            "city_name": "City 23",
            "country_id": 33
        },
        {
            "city_id": 24,
            "city_name": "City 24",
            "country_id": 10
        },
        {
            "city_id": 25,
            "city_name": "City 25",
            "country_id": 67
        },
        {
            "city_id": 26,
            "city_name": "City 26",
            "country_id": 5
        },
        {
            "city_id": 27,
            "city_name": "City 27",
            "country_id": 28
        },
        {
            "city_id": 28,
            "city_name": "City 28",
            "country_id": 20
        },
        {
            "city_id": 29,
            "city_name": "City 29",
            "country_id": 59
        },
        {
            "city_id": 30,
            "city_name": "City 30",
            "country_id": 84
        }
    ]
}
```

when we run docker-compose up with "fetch_key":"city_id" we get a dict with 29 cities. Notice how City 30 is not part of the dict.

```json
{
    "result": {
        "1": {
            "city_id": 1,
            "city_name": "City 1",
            "country_id": 95
        },
        "10": {
            "city_id": 10,
            "city_name": "City 10",
            "country_id": 65
        },
        "11": {
            "city_id": 11,
            "city_name": "City 11",
            "country_id": 7
        },
        "12": {
            "city_id": 12,
            "city_name": "City 12",
            "country_id": 33
        },
        "13": {
            "city_id": 13,
            "city_name": "City 13",
            "country_id": 12
        },
        "14": {
            "city_id": 14,
            "city_name": "City 14",
            "country_id": 72
        },
        "15": {
            "city_id": 15,
            "city_name": "City 15",
            "country_id": 44
        },
        "16": {
            "city_id": 16,
            "city_name": "City 16",
            "country_id": 77
        },
        "17": {
            "city_id": 17,
            "city_name": "City 17",
            "country_id": 89
        },
        "18": {
            "city_id": 18,
            "city_name": "City 18",
            "country_id": 56
        },
        "19": {
            "city_id": 19,
            "city_name": "City 19",
            "country_id": 46
        },
        "2": {
            "city_id": 2,
            "city_name": "City 2",
            "country_id": 52
        },
        "20": {
            "city_id": 20,
            "city_name": "City 20",
            "country_id": 45
        },
        "21": {
            "city_id": 21,
            "city_name": "City 21",
            "country_id": 40
        },
        "22": {
            "city_id": 22,
            "city_name": "City 22",
            "country_id": 81
        },
        "23": {
            "city_id": 23,
            "city_name": "City 23",
            "country_id": 33
        },
        "24": {
            "city_id": 24,
            "city_name": "City 24",
            "country_id": 10
        },
        "25": {
            "city_id": 25,
            "city_name": "City 25",
            "country_id": 67
        },
        "26": {
            "city_id": 26,
            "city_name": "City 26",
            "country_id": 5
        },
        "27": {
            "city_id": 27,
            "city_name": "City 27",
            "country_id": 28
        },
        "28": {
            "city_id": 28,
            "city_name": "City 28",
            "country_id": 20
        },
        "29": {
            "city_id": 29,
            "city_name": "City 29",
            "country_id": 59
        },
        "3": {
            "city_id": 3,
            "city_name": "City 3",
            "country_id": 1
        },
        "4": {
            "city_id": 4,
            "city_name": "City 4",
            "country_id": 51
        },
        "5": {
            "city_id": 5,
            "city_name": "City 5",
            "country_id": 52
        },
        "6": {
            "city_id": 6,
            "city_name": "City 6",
            "country_id": 55
        },
        "7": {
            "city_id": 7,
            "city_name": "City 7",
            "country_id": 37
        },
        "8": {
            "city_id": 8,
            "city_name": "City 8",
            "country_id": 22
        },
        "9": {
            "city_id": 9,
            "city_name": "City 9",
            "country_id": 80
        }
    }
}
```

When removing the -1 and running docker-compose up with "fetch_key":"city_id" we get a dict containing 30 cities. notice how City 30 is now included.

```json
{
    "result": {
        "1": {
            "city_id": 1,
            "city_name": "City 1",
            "country_id": 53
        },
        "10": {
            "city_id": 10,
            "city_name": "City 10",
            "country_id": 6
        },
        "11": {
            "city_id": 11,
            "city_name": "City 11",
            "country_id": 57
        },
        "12": {
            "city_id": 12,
            "city_name": "City 12",
            "country_id": 40
        },
        "13": {
            "city_id": 13,
            "city_name": "City 13",
            "country_id": 87
        },
        "14": {
            "city_id": 14,
            "city_name": "City 14",
            "country_id": 7
        },
        "15": {
            "city_id": 15,
            "city_name": "City 15",
            "country_id": 90
        },
        "16": {
            "city_id": 16,
            "city_name": "City 16",
            "country_id": 65
        },
        "17": {
            "city_id": 17,
            "city_name": "City 17",
            "country_id": 94
        },
        "18": {
            "city_id": 18,
            "city_name": "City 18",
            "country_id": 95
        },
        "19": {
            "city_id": 19,
            "city_name": "City 19",
            "country_id": 53
        },
        "2": {
            "city_id": 2,
            "city_name": "City 2",
            "country_id": 94
        },
        "20": {
            "city_id": 20,
            "city_name": "City 20",
            "country_id": 11
        },
        "21": {
            "city_id": 21,
            "city_name": "City 21",
            "country_id": 55
        },
        "22": {
            "city_id": 22,
            "city_name": "City 22",
            "country_id": 27
        },
        "23": {
            "city_id": 23,
            "city_name": "City 23",
            "country_id": 80
        },
        "24": {
            "city_id": 24,
            "city_name": "City 24",
            "country_id": 78
        },
        "25": {
            "city_id": 25,
            "city_name": "City 25",
            "country_id": 59
        },
        "26": {
            "city_id": 26,
            "city_name": "City 26",
            "country_id": 58
        },
        "27": {
            "city_id": 27,
            "city_name": "City 27",
            "country_id": 69
        },
        "28": {
            "city_id": 28,
            "city_name": "City 28",
            "country_id": 68
        },
        "29": {
            "city_id": 29,
            "city_name": "City 29",
            "country_id": 28
        },
        "3": {
            "city_id": 3,
            "city_name": "City 3",
            "country_id": 52
        },
        "30": {
            "city_id": 30,
            "city_name": "City 30",
            "country_id": 15
        },
        "4": {
            "city_id": 4,
            "city_name": "City 4",
            "country_id": 100
        },
        "5": {
            "city_id": 5,
            "city_name": "City 5",
            "country_id": 7
        },
        "6": {
            "city_id": 6,
            "city_name": "City 6",
            "country_id": 2
        },
        "7": {
            "city_id": 7,
            "city_name": "City 7",
            "country_id": 65
        },
        "8": {
            "city_id": 8,
            "city_name": "City 8",
            "country_id": 63
        },
        "9": {
            "city_id": 9,
            "city_name": "City 9",
            "country_id": 10
        }
    }
}
```